### PR TITLE
add the base config for nushell as a login shell

### DIFF
--- a/.config/nushell/login.nu
+++ b/.config/nushell/login.nu
@@ -1,0 +1,9 @@
+# Example Nushell Loginshell Config File
+# - has to be as login.nu in the default config directory
+# - will be sourced after config.nu and env.nu in case of nushell started as login shell
+
+# just as an example for overwriting of an environment variable of env.nu
+let-env PROMPT_INDICATOR = { "(LS)〉" }
+
+# Similar to env-path and config-path there is a variable containing the path to login.nu
+echo $nu.loginshell-path


### PR DESCRIPTION
This PR adds the default [login.nu](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/sample_login.nu) config file from the `nushell` source repo in `~/.config/nushell/login.nu`.