### PR TITLE
NUSHELL: add a script to download youtube videos metadata

### DIFF
--- a/.config/nushell/scripts/functions.nu
+++ b/.config/nushell/scripts/functions.nu
@@ -118,6 +118,9 @@ def yt-dl-names [
         $"https://www.youtube.com/playlist?list=($id)"
     }
 
+    if (ls | find $path | empty?) {
+        mkdir $path
+    }
     let file = ($path | path join $"($id).csv")
 
     print $"Downloading from '($url)' to ($file)..."

--- a/.config/nushell/scripts/functions.nu
+++ b/.config/nushell/scripts/functions.nu
@@ -110,7 +110,7 @@ def yt-dl-names [
     --path (-p): string = .  # the path where to store to final `.csv` file
     --all (-a)  # download all the playlists from the channel when raised
 ] {
-    let format = '"%(playlists)s,%(playlist_id)s,%(playlist_index)s,"%(uploader)s","%(title)s,%(id)s'
+    let format = '"%(playlist)s",%(playlist_id)s,%(playlist_index)s,"%(uploader)s","%(title)s",%(id)s'
 
     let url = if $all {
         $"https://www.youtube.com/channel/($channel)/playlists"

--- a/.config/nushell/scripts/functions.nu
+++ b/.config/nushell/scripts/functions.nu
@@ -104,6 +104,40 @@ def-env vcfg [] {
 }
 
 
+def yt-dl-names [
+    --id (-i): string  # the id of the playlist
+    --channel (-c): string  # the id of the channel
+    --path (-p): string = .  # the path where to store to final `.csv` file
+    --all (-a)  # download all the playlists from the channel when raised
+] {
+    let format = '"%(playlists)s,%(playlist_id)s,%(playlist_index)s,"%(uploader)s","%(title)s,%(id)s'
+
+    let url = if $all {
+        $"https://www.youtube.com/channel/($channel)/playlists"
+      } else {
+        $"https://www.youtube.com/playlist?list=($id)"
+    }
+
+    let file = ($path | path join $"($id).csv")
+
+    print $"Downloading from '($url)' to ($file)..."
+
+    (youtube-dl
+        -o $format
+        $url
+        --get-filename
+        --skip-download
+    ) |
+    from csv --noheaders |
+    rename playlist "playlist id" "playlist index" uploader title id |
+    insert url {
+        |it|
+        $'https://www.youtube.com/watch?v=($it.id)&list=($it."playlist id")'
+    } |
+    save $file
+}
+
+
 def "nu-complete help categories" [] {
     help commands | get category | uniq
 }

--- a/.config/nushell/scripts/functions.nu
+++ b/.config/nushell/scripts/functions.nu
@@ -130,6 +130,7 @@ def yt-dl-names [
         $url
         --get-filename
         --skip-download
+        --verbose
     ) |
     from csv --noheaders |
     rename playlist "playlist id" "playlist index" uploader title id |


### PR DESCRIPTION
This PR adds the `yt-dl-names` function to `nushell`.
This function allows the user, by giving either a playlist `--id` or a `--channel` id, to download the list of videos inside a playlist or all the playlists of a channel with the `--all` flag.